### PR TITLE
Add Currency.Common library

### DIFF
--- a/Personal-Finance/Personal-Finance.sln
+++ b/Personal-Finance/Personal-Finance.sln
@@ -1,10 +1,33 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.12.35527.113 d17.12
+VisualStudioVersion = 17.12.35527.113
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Services", "Services", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Currency", "Currency", "{ECF3C097-3169-4F10-B80B-D1C93B6BA8DD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Currency.Common", "Services\Currency\Currency.Common\Currency.Common.csproj", "{E63D4D7B-E151-4989-B246-1D1980D4FD77}"
+EndProject
 Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E63D4D7B-E151-4989-B246-1D1980D4FD77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E63D4D7B-E151-4989-B246-1D1980D4FD77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E63D4D7B-E151-4989-B246-1D1980D4FD77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E63D4D7B-E151-4989-B246-1D1980D4FD77}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{ECF3C097-3169-4F10-B80B-D1C93B6BA8DD} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{E63D4D7B-E151-4989-B246-1D1980D4FD77} = {ECF3C097-3169-4F10-B80B-D1C93B6BA8DD}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0C571D7B-A098-459C-8B8D-CEAF18D38B9F}
 	EndGlobalSection
 EndGlobal

--- a/Personal-Finance/Services/Currency/Currency.Common/Currency.Common.csproj
+++ b/Personal-Finance/Services/Currency/Currency.Common/Currency.Common.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Personal-Finance/Services/Currency/Currency.Common/Currency.Common.csproj
+++ b/Personal-Finance/Services/Currency/Currency.Common/Currency.Common.csproj
@@ -13,6 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/Personal-Finance/Services/Currency/Currency.Common/Currency.Common.csproj
+++ b/Personal-Finance/Services/Currency/Currency.Common/Currency.Common.csproj
@@ -6,4 +6,14 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Folder Include="DTOs\" />
+    <Folder Include="Data\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.8" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/Personal-Finance/Services/Currency/Currency.Common/Entities/CurrencyRate.cs
+++ b/Personal-Finance/Services/Currency/Currency.Common/Entities/CurrencyRate.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Currency.Common.Entities
+{
+    internal class CurrencyRate
+    {
+        public string Code { get; set; }
+        public DateTime Date { get; set; }
+        public decimal MiddleRate { get; set; }
+    }
+}

--- a/Personal-Finance/Services/Currency/Currency.Common/Entities/CurrencyRateList.cs
+++ b/Personal-Finance/Services/Currency/Currency.Common/Entities/CurrencyRateList.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Currency.Common.Entities
+{
+    internal class CurrencyRateList
+    {
+        public string Username { get; set; }
+        public List<CurrencyRate> Rates { get; set; } = new List<CurrencyRate>();
+    }
+}

--- a/Personal-Finance/Services/Currency/Currency.Common/Extensions/CurrencyCommonExtensions.cs
+++ b/Personal-Finance/Services/Currency/Currency.Common/Extensions/CurrencyCommonExtensions.cs
@@ -1,0 +1,25 @@
+﻿using Currency.Common.Repositories;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Currency.Common.Extensions
+{
+    public static class CurrencyCommonExtensions
+    {
+        // we will call it in out projects as service.AddCurrencyCommonServices(_configuration);
+        public static void AddCurrencyCommonServices(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddStackExchangeRedisCache(options => {
+                options.Configuration = configuration.GetValue<string>("CacheSettings:ConnectionString");
+            });
+            services.AddScoped<ICurrencyRatesRepository,  CurrencyRatesRepository>();
+        }
+    }
+}

--- a/Personal-Finance/Services/Currency/Currency.Common/Repositories/CurrencyRatesRepository.cs
+++ b/Personal-Finance/Services/Currency/Currency.Common/Repositories/CurrencyRatesRepository.cs
@@ -1,0 +1,47 @@
+﻿using Currency.Common.Entities;
+using Microsoft.Extensions.Caching.Distributed;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+namespace Currency.Common.Repositories
+{
+    internal class CurrencyRatesRepository : ICurrencyRatesRepository
+    {
+        private readonly IDistributedCache _cache;
+
+        public CurrencyRatesRepository(IDistributedCache cache)
+        {
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        }
+
+        public async Task<CurrencyRateList> GetRates(string username)
+        {
+            var rates = await _cache.GetStringAsync(username);
+
+            if (string.IsNullOrEmpty(rates)) {
+                return null;
+            }
+
+            return JsonConvert.DeserializeObject<CurrencyRateList>(rates);
+        }
+
+        public async Task<CurrencyRateList> UpdateRates(CurrencyRateList currencyRateList)
+        {
+            var ratesString = JsonConvert.SerializeObject(currencyRateList);
+
+            await _cache.SetStringAsync(currencyRateList.Username, ratesString);
+
+            return await GetRates(currencyRateList.Username);
+        }
+
+        public async Task DeleteRates(string username)
+        {
+            await _cache.RemoveAsync(username);
+        }
+    }
+}

--- a/Personal-Finance/Services/Currency/Currency.Common/Repositories/ICurrencyRatesRepository.cs
+++ b/Personal-Finance/Services/Currency/Currency.Common/Repositories/ICurrencyRatesRepository.cs
@@ -1,0 +1,17 @@
+﻿using Currency.Common.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Currency.Common.Repositories
+{
+    internal interface ICurrencyRatesRepository
+    {
+        Task<CurrencyRateList> GetRates(string username);
+        Task<CurrencyRateList> UpdateRates(CurrencyRateList currencyRateList);
+
+        Task DeleteRates(string username);
+    }
+}


### PR DESCRIPTION
This PR introduces the **`Currency.Common`** library which includes:

- `AddCurrencyCommonServices` extension method for registering services
  - Redis cache (uses `CacheSettings:ConnectionString`)
  - Registered ICurrencyRatesRepository with scoped lifetime in DI container
  - Enables automatic injection of `CurrencyRatesRepository` wherever `ICurrencyRatesRepository` is needed
- Entities
  -  `CurrencyRate` - simple single currency rate information (all transactions use middle rate)
  -  `CurrencyRateList` - a list of `CurrencyRate`-s for a user (based on username)
- Repositories
  - `ICurrencyRatesRepository`
  - `CurrencyRatesRepository`

Closes #4 