### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kracunovic92 @misikori @Stefan-Dr @Markic01


### PR DESCRIPTION
CODEOWNERS file automatically adds all users as reviewers so there is no need for individual clicking to select everyone