### PR TITLE
refactor: format style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,10 +55,11 @@ dotnet_sort_system_directives_first = true
 file_header_template = unset
 
 # Analyzer severity
-dotnet_analyzer_diagnostic.category-Style.severity = warning
-dotnet_analyzer_diagnostic.category-Naming.severity = warning
-dotnet_analyzer_diagnostic.category-Maintainability.severity = warning
-dotnet_analyzer_diagnostic.category-Reliability.severity = warning
-dotnet_analyzer_diagnostic.category-Performance.severity = warning
-dotnet_analyzer_diagnostic.category-Security.severity = warning
+dotnet_analyzer_diagnostic.category-Style.severity = silent
+dotnet_analyzer_diagnostic.category-Naming.severity = silent
+dotnet_analyzer_diagnostic.category-Maintainability.severity = silent
+dotnet_analyzer_diagnostic.category-Reliability.severity = silent
+dotnet_analyzer_diagnostic.category-Performance.severity = silent
+dotnet_analyzer_diagnostic.category-Security.severity = silent
+dotnet_diagnostic.CA1848.severity = none
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: dotnet-format
         name: dotnet-format
-        entry: dotnet format Personal-Finance/Personal-Finance.sln --verify-no-changes
+        entry: bash -c 'dotnet format style --verify-no-changes --include $(git diff --cached --name-only --diff-filter=ACM | tr "\n" " ")'
         language: system
         pass_filenames: false
         types_or: [c#]


### PR DESCRIPTION
### Problem description
Local formatter now takes only staged changes into consideration. Disable dotnet analyzer when executing `dotnet format`

### What's changed
`pre-commit.yaml` hook modified along with `.editorconfig` where we keep formatting rules.
